### PR TITLE
syncAll flag added to FIFODISKQUEUE

### DIFF
--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -53,10 +53,13 @@ class FifoDiskQueue(object):
         hpos += 1
         szhdr = struct.pack(self.szhdr_format, len(string))
         os.write(self.headf.fileno(), szhdr + string)
-        if self.headf.tell() >= self.chunksize:
+        print self.headf.tell()
+        print self.chunksize
+        if self.headf.tell() >= self.chunksize: #roll to next chunk
             hpos = 0
             hnum += 1
             self.headf.close()
+            print "rolling"
             self.headf = self._openchunk(hnum, 'ab+')
         self.info['size'] += 1
         self.info['head'] = [hnum, self.headf.tell()]

--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -37,10 +37,11 @@ class FifoDiskQueue(object):
     szhdr_format = ">L"
     szhdr_size = struct.calcsize(szhdr_format)
 
-    def __init__(self, path, chunksize=100000):
+    def __init__(self, path, chunksize=100000, syncAll=False):
         self.path = path
         if not os.path.exists(path):
             os.makedirs(path)
+        self.syncAll = syncAll
         self.info = self._loadinfo(chunksize)
         self.chunksize = self.info['chunksize']
         self.headf = self._openchunk(self.info['head'][0], 'ab+')
@@ -59,6 +60,9 @@ class FifoDiskQueue(object):
             self.headf = self._openchunk(hnum, 'ab+')
         self.info['size'] += 1
         self.info['head'] = [hnum, hpos]
+        
+        if self.syncAll==True:
+            self._saveinfo(self.info)
 
     def _openchunk(self, number, mode='r'):
         return open(os.path.join(self.path, 'q%05d' % number), mode)
@@ -83,6 +87,9 @@ class FifoDiskQueue(object):
             self.tailf = self._openchunk(tnum)
         self.info['size'] -= 1
         self.info['tail'] = [tnum, tcnt, toffset]
+        if self.syncAll==True:
+            self._saveinfo(self.info)
+        
         return data
 
     def close(self):

--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -53,7 +53,7 @@ class FifoDiskQueue(object):
         hpos += 1
         szhdr = struct.pack(self.szhdr_format, len(string))
         os.write(self.headf.fileno(), szhdr + string)
-        if self.headf.tell() >= self.chunksize:  # roll to next chunk
+        if self.headf.tell() >= self.chunksize:  # Roll to next chunk
             hpos = 0
             hnum += 1
             self.headf.close()

--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -53,7 +53,7 @@ class FifoDiskQueue(object):
         hpos += 1
         szhdr = struct.pack(self.szhdr_format, len(string))
         os.write(self.headf.fileno(), szhdr + string)
-        if self.headf.tell() >= self.chunksize: #roll to next chunk
+        if self.headf.tell() >= self.chunksize:  # roll to next chunk
             hpos = 0
             hnum += 1
             self.headf.close()

--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -53,13 +53,10 @@ class FifoDiskQueue(object):
         hpos += 1
         szhdr = struct.pack(self.szhdr_format, len(string))
         os.write(self.headf.fileno(), szhdr + string)
-        print self.headf.tell()
-        print self.chunksize
         if self.headf.tell() >= self.chunksize: #roll to next chunk
             hpos = 0
             hnum += 1
             self.headf.close()
-            print "rolling"
             self.headf = self._openchunk(hnum, 'ab+')
         self.info['size'] += 1
         self.info['head'] = [hnum, self.headf.tell()]

--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -53,13 +53,13 @@ class FifoDiskQueue(object):
         hpos += 1
         szhdr = struct.pack(self.szhdr_format, len(string))
         os.write(self.headf.fileno(), szhdr + string)
-        if hpos == self.chunksize:
+        if self.headf.tell() >= self.chunksize:
             hpos = 0
             hnum += 1
             self.headf.close()
             self.headf = self._openchunk(hnum, 'ab+')
         self.info['size'] += 1
-        self.info['head'] = [hnum, hpos]
+        self.info['head'] = [hnum, self.headf.tell()]
         
         if self.syncAll==True:
             self._saveinfo(self.info)

--- a/queuelib/tests/test_queue.py
+++ b/queuelib/tests/test_queue.py
@@ -142,6 +142,9 @@ class FifoDiskQueueTest(FifoMemoryQueueTest):
             q.push(x)
 
         chunks = glob.glob(os.path.join(self.qdir, 'q*'))
+        print len(chunks)
+        print self.chunksize
+        print len(q)
         self.assertEqual(len(chunks), 5 // self.chunksize + 1)
         for x in values:
             q.pop()

--- a/queuelib/tests/test_queue.py
+++ b/queuelib/tests/test_queue.py
@@ -142,9 +142,6 @@ class FifoDiskQueueTest(FifoMemoryQueueTest):
             q.push(x)
 
         chunks = glob.glob(os.path.join(self.qdir, 'q*'))
-        print len(chunks)
-        print self.chunksize
-        print len(q)
         self.assertEqual(len(chunks), 5 // self.chunksize + 1)
         for x in values:
             q.pop()


### PR DESCRIPTION
I had an issue that if i did not call close then the info was file was not written and because it was not written when i went to open the queue again it would not know of any of the documents and if i added a pushed a doc then poped it then the oldest doc would come out. For the time being i have added a syncAll flag so everytime it does the write it will also write the info file 
