### PR TITLE
In windows, must open disk queue file in binary mode

### DIFF
--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -60,7 +60,7 @@ class FifoDiskQueue(object):
         self.info['size'] += 1
         self.info['head'] = [hnum, hpos]
 
-    def _openchunk(self, number, mode='r'):
+    def _openchunk(self, number, mode='rb'):
         return open(os.path.join(self.path, 'q%05d' % number), mode)
 
     def pop(self):

--- a/queuelib/tests/test_queue.py
+++ b/queuelib/tests/test_queue.py
@@ -112,6 +112,15 @@ class FifoDiskQueueTest(FifoMemoryQueueTest):
     def queue(self):
         return FifoDiskQueue(self.qdir, chunksize=self.chunksize)
 
+    def test_text_in_windows(self):
+        e1 = b'\r\n'
+        q = self.queue()
+        q.push(e1)
+        q.close()
+        q = self.queue()
+        e2 = q.pop()
+        self.assertEqual(e1, e2)
+
     def test_close_open(self):
         """Test closing and re-opening keeps state"""
         q = self.queue()


### PR DESCRIPTION
As discussed in https://github.com/scrapy/queuelib/issues/6
Without the binary mode in _openchunk, `os.read(n)` will read less data than specified in `n` even though there are more bytes available.
