### PR TITLE
SQLite persistent queue

### DIFF
--- a/queuelib/tests/test_queue.py
+++ b/queuelib/tests/test_queue.py
@@ -1,7 +1,10 @@
 import os
 import glob
 
-from queuelib.queue import FifoMemoryQueue, LifoMemoryQueue, FifoDiskQueue, LifoDiskQueue
+from queuelib.queue import (
+    FifoMemoryQueue, LifoMemoryQueue, FifoDiskQueue, LifoDiskQueue,
+    FifoSQLiteQueue, LifoSQLiteQueue,
+)
 from queuelib.tests import QueuelibTestCase
 
 
@@ -220,5 +223,13 @@ class LifoDiskQueueTest(LifoTestMixin, PersistentTestMixin, QueuelibTestCase):
         assert os.path.getsize(self.qpath), size
 
 
+class FifoSQLiteQueueTest(FifoTestMixin, PersistentTestMixin, QueuelibTestCase):
+
+    def queue(self):
+        return FifoSQLiteQueue(self.qpath)
 
 
+class LifoSQLiteQueueTest(LifoTestMixin, PersistentTestMixin, QueuelibTestCase):
+
+    def queue(self):
+        return LifoSQLiteQueue(self.qpath)


### PR DESCRIPTION
This pull request regroups test cases so it is easier to reuse them on different queue implementations and adds a new persistent queue based on sqlite.

I don't recall why we invented queuelib, bare traces of memory says it was because sqlite support wasn't compile for the python2.5 version we used by that time but I can't affirm that.

Current implementation of persistent disk queue not based on sqlite corrupts easily if the process or system crashes, in that sense sqlite is more robust [according to its docs](https://www.sqlite.org/howtocorrupt.html)

I will run benchmarks on different push/pop workloads and compare disk usage. 