### PR TITLE
Undo write if it fails.

### DIFF
--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -149,9 +149,16 @@ class LifoDiskQueue(object):
     def push(self, string):
         if not isinstance(string, bytes):
             raise TypeError('Unsupported type: {}'.format(type(string).__name__))
-        self.f.write(string)
-        ssize = struct.pack(self.SIZE_FORMAT, len(string))
-        self.f.write(ssize)
+        pos = self.f.tell()
+        try:
+            self.f.write(string)
+            ssize = struct.pack(self.SIZE_FORMAT, len(string))
+            self.f.write(ssize)
+            self.f.flush()
+        except:
+            self.f.seek(pos)
+            self.f.truncate()
+            raise
         self.size += 1
 
     def pop(self):

--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -155,7 +155,7 @@ class LifoDiskQueue(object):
             ssize = struct.pack(self.SIZE_FORMAT, len(string))
             self.f.write(ssize)
             self.f.flush()
-        except:
+        except IOError:
             self.f.seek(pos)
             self.f.truncate()
             raise


### PR DESCRIPTION
Fixes #14.

The `flush()` is necessary because of the following scenario:
- write exceeds fs capacity but isn't flushed, write call doesn't fail, file is at position beyond fs capacity;
- next call writes enough to flush;
- next call fails but going back to previous position still exceeds fs capacity;

It could however become a performance issue. Could be fixed by a file object that keeps a buffer in memory by itself and only calls write in KB-sized blocks.
