### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,23 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
-
+ #Including power support ppc64le     
+    - arch: ppc64le
+      python: 2.7
+      env: TOXENV=py27
+    - arch: ppc64le
+      python: 3.5
+      env: TOXENV=py35
+    - arch: ppc64le
+      python: 3.6
+      env: TOXENV=py36
+    - arch: ppc64le
+      python: 3.7
+      env: TOXENV=py37
+    - arch: ppc64le
+      python: 3.8
+      env: TOXENV=py38  
+      
 install:
   - |
       if [ "$TOXENV" = "pypy" ]; then


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.