### PR TITLE
Remove object as base class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ language: python
 sudo: false
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 2.7
-      env: TOXENV=pypy
     - python: 3.5
       env: TOXENV=py35
     - python: 3.5
@@ -19,13 +15,6 @@ matrix:
 
 install:
   - |
-      if [ "$TOXENV" = "pypy" ]; then
-        export PYPY_VERSION="pypy2-v5.9.0-linux64"
-        wget "https://downloads.python.org/pypy/${PYPY_VERSION}.tar.bz2"
-        tar -jxf ${PYPY_VERSION}.tar.bz2
-        virtualenv --python="$PYPY_VERSION/bin/pypy" "$HOME/virtualenvs/$PYPY_VERSION"
-        source "$HOME/virtualenvs/$PYPY_VERSION/bin/activate"
-      fi
       if [ "$TOXENV" = "pypy3" ]; then
         export PYPY_VERSION="pypy3-v5.9.0-linux64"
         wget "https://downloads.python.org/pypy/${PYPY_VERSION}.tar.bz2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: TOXENV=py37
     - python: 3.8
       env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
 
 install:
   - |

--- a/queuelib/pqueue.py
+++ b/queuelib/pqueue.py
@@ -1,4 +1,4 @@
-class PriorityQueue(object):
+class PriorityQueue:
     """A priority queue implemented using multiple internal queues (typically,
     FIFO queues). The internal queue must implement the following methods:
 

--- a/queuelib/queue.py
+++ b/queuelib/queue.py
@@ -6,7 +6,7 @@ import sqlite3
 from collections import deque
 
 
-class FifoMemoryQueue(object):
+class FifoMemoryQueue:
     """In-memory FIFO queue, API compliant with FifoDiskQueue."""
 
     def __init__(self):
@@ -32,7 +32,7 @@ class LifoMemoryQueue(FifoMemoryQueue):
         return q.pop() if q else None
 
 
-class FifoDiskQueue(object):
+class FifoDiskQueue:
     """Persistent FIFO queue."""
 
     szhdr_format = ">L"
@@ -128,7 +128,7 @@ class FifoDiskQueue(object):
 
 
 
-class LifoDiskQueue(object):
+class LifoDiskQueue:
     """Persistent LIFO queue."""
 
     SIZE_FORMAT = ">L"
@@ -178,7 +178,7 @@ class LifoDiskQueue(object):
         return self.size
 
 
-class FifoSQLiteQueue(object):
+class FifoSQLiteQueue:
 
     _sql_create = (
         'CREATE TABLE IF NOT EXISTS queue '

--- a/queuelib/rrqueue.py
+++ b/queuelib/rrqueue.py
@@ -1,6 +1,6 @@
 from collections import deque
 
-class RoundRobinQueue(object):
+class RoundRobinQueue:
     """A round robin queue implemented using multiple internal queues (typically,
     FIFO queues). The internal queue must implement the following methods:
         * push(obj)

--- a/queuelib/tests/test_pqueue.py
+++ b/queuelib/tests/test_pqueue.py
@@ -60,7 +60,7 @@ class base:
             assert p1queue.closed
 
 
-class FifoTestMixin(object):
+class FifoTestMixin:
 
     def test_push_pop_noprio(self):
         self.q.push(b'a')
@@ -83,7 +83,7 @@ class FifoTestMixin(object):
         self.assertEqual(self.q.pop(), None)
 
 
-class LifoTestMixin(object):
+class LifoTestMixin:
 
     def test_push_pop_noprio(self):
         self.q.push(b'a')
@@ -118,7 +118,7 @@ class LifoMemoryPriorityQueueTest(LifoTestMixin, base.PQueueTestBase):
         return track_closed(LifoMemoryQueue)()
 
 
-class DiskTestMixin(object):
+class DiskTestMixin:
 
     def test_nonserializable_object_one(self):
         self.assertRaises(TypeError, self.q.push, lambda x: x, 0)

--- a/queuelib/tests/test_queue.py
+++ b/queuelib/tests/test_queue.py
@@ -9,7 +9,7 @@ from queuelib.queue import (
 from queuelib.tests import QueuelibTestCase
 
 
-class BaseQueueTest(object):
+class BaseQueueTest:
 
     def queue(self):
         return NotImplementedError()
@@ -106,7 +106,7 @@ class LifoTestMixin(BaseQueueTest):
         self.assertEqual(q.pop(), b'a')
 
 
-class PersistentTestMixin(object):
+class PersistentTestMixin:
 
     chunksize = 100000
 

--- a/queuelib/tests/test_rrqueue.py
+++ b/queuelib/tests/test_rrqueue.py
@@ -51,7 +51,7 @@ class base:
             self.assertEqual(sorted(self.q.close()), ['2', '3'])
 
 
-class FifoTestMixin(object):
+class FifoTestMixin:
     def test_push_pop_key(self):
         self.q.push(b'a', '1')
         self.q.push(b'b', '1')
@@ -64,7 +64,7 @@ class FifoTestMixin(object):
         self.assertEqual(self.q.pop(), None)
 
 
-class LifoTestMixin(object):
+class LifoTestMixin:
 
     def test_push_pop_key(self):
         self.q.push(b'a', '1')
@@ -90,7 +90,7 @@ class LifoMemoryRRQueueTest(LifoTestMixin, base.RRQueueTestBase):
         return track_closed(LifoMemoryQueue)()
 
 
-class DiskTestMixin(object):
+class DiskTestMixin:
 
     def test_nonserializable_object_one(self):
         self.assertRaises(TypeError, self.q.push, lambda x: x, '0')


### PR DESCRIPTION
Not necessary anymore after #37. ~Travis's tests fail for py2, but #36~

Edit: also remove the py2 jobs from Travis and add py39.