### PR TITLE
Pin versions in tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py35, py36, py37, py38, py39, pypy3, black, flake8, pylint, security, 
 [testenv]
 deps =
     pytest !=3.1.1, !=3.1.2
-    pytest-cov
+    pytest-cov==2.11.1
 commands =
     py.test --cov=queuelib --cov-report=xml --cov-report=term --cov-report=html {posargs:queuelib}
 
@@ -23,7 +23,7 @@ commands =
 [testenv:flake8]
 basepython = python3
 deps =
-    flake8
+    flake8==3.9.1
 commands =
     flake8 {posargs:queuelib setup.py}
 
@@ -31,14 +31,14 @@ commands =
 basepython = python3
 deps =
     {[testenv]deps}
-    pylint
+    pylint==2.7.4
 commands =
     pylint {posargs:queuelib setup.py}
 
 [testenv:security]
 basepython = python3
 deps =
-    bandit
+    bandit==1.7.0
 commands =
     bandit -r -c .bandit.yml {posargs:queuelib setup.py}
 


### PR DESCRIPTION
The difference between https://github.com/scrapy/queuelib/runs/2427904684?check_suite_focus=true#step:4:63 and https://github.com/scrapy/queuelib/runs/2428828505?check_suite_focus=true#step:4:63 is the pylint upgrade (2.7.4 -> 2.8.0) 