### PR TITLE
Make importing memory queues from the package possible

### DIFF
--- a/queuelib/__init__.py
+++ b/queuelib/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "1.6.1"
 
-from queuelib.queue import FifoDiskQueue, LifoDiskQueue
+from queuelib.queue import FifoDiskQueue, LifoDiskQueue, FifoMemoryQueue, LifoMemoryQueue
 from queuelib.pqueue import PriorityQueue
 from queuelib.rrqueue import RoundRobinQueue


### PR DESCRIPTION
Right now to use the memory queues, we have to do this:
```
from queuelib.queue import FifoMemoryQueue, LifoMemoryQueue
```

This PR lets us do this:
```
from queuelib import FifoMemoryQueue, LifoMemoryQueue
```

This has readability gains because it means we can write:
```
from queuelib import FifoMemoryQueue, LifoMemoryQueue, PriorityQueue
```

Instead of:
```
from queuelib.queue import FifoMemoryQueue, LifoMemoryQueue, PriorityQueue
from queuelib.pqueue import PriorityQueue
```

Unless this is intentional to discourage using non-disk queues, this change should improve library ergonomics.